### PR TITLE
doc: Switch changelog to reverse-chronological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to the "matter-for-vscode" extension will be documented in t
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [0.1.0] - 2020-09-06
-### Added
-- functionality to spawn a matlab terminal in vscode
-- functionality to run matlab scripts in vscode
-
 ## [0.1.3] - 2020-09-06
+
 ### Added
+
 - icon for vscode marketplace
 - changed name in vscode marketplace
+
+## [0.1.0] - 2020-09-06
+
+### Added
+
+- functionality to spawn a matlab terminal in vscode
+- functionality to run matlab scripts in vscode


### PR DESCRIPTION
[Keep a Changelog](http://keepachangelog.com/) recommends using reverse chronological order. (It doesn't say this explicitly as far as I can tell, but the example on their main page is reverse-chron.)

Reverse chronological order puts the most recent releases, which most changelog readers would be most interested in, I think, at the top of the page and easy to find.

This change also tweaks the markdown formatting a bit, adding spaces between headings, to conform to markdown-lint and what I see most Markdown authors using in public these days.