### PR TITLE
Add -nosplash to suppress splash window on terminal startup

### DIFF
--- a/src/matter/matter.ts
+++ b/src/matter/matter.ts
@@ -8,7 +8,7 @@ export class Matter implements MatlabTerminal{
     static terminalSettings: vscode.TerminalOptions = { 
         name : "Matlab Terminal",
         shellPath: "/usr/bin/env",
-        shellArgs: ["matlab", "-nodesktop"]
+        shellArgs: ["matlab", "-nodesktop", "-nosplash"]
     }
     public terminal: vscode.Terminal;
     constructor(matter: MatlabTerminal){


### PR DESCRIPTION
When I fire up a MatTer Matlab terminal in VS Code, I get a graphical Matlab splash window while it's loading. That seems distracting. How about using the `-nosplash` to suppress it?