### PR TITLE
remove "Congratulations" alert in extension startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,10 +7,6 @@ import * as matter from './matter/matter';
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 	
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	vscode.window.showInformationMessage('Congratulations, your extension "matter-for-vscode" is now active!');
-
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json


### PR DESCRIPTION
Fixes #11, the "Congratulations" alert message that pops up when the extension starts.